### PR TITLE
feat(backend): confirm email

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5142,14 +5142,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5142,6 +5142,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,11 +12,14 @@ app.use("/v1", v1);
 const init = async () => {
   try {
     await connect(DB_URI);
-    app.listen(PORT, () => {
-      console.log(
-        `PORT ${PORT} | ENV ${NODE_ENV} | Server is running | Connected to database`,
-      );
-    });
+    // see: https://stackoverflow.com/a/63293781
+    if (process.env.NODE_ENV !== "test") {
+      app.listen(PORT, () => {
+        console.log(
+          `PORT ${PORT} | ENV ${NODE_ENV} | Server is running | Connected to database`,
+        );
+      });
+    }
   } catch (error) {
     console.error("An error occured while init the server", error);
   }

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -1,6 +1,6 @@
-import { body } from "express-validator";
+import { body, query } from "express-validator";
 
-export const signupValidationChain = [
+export const signupVC = [
   body("username")
     .notEmpty()
     .withMessage("username is required")
@@ -26,4 +26,8 @@ export const signupValidationChain = [
     .withMessage(
       "password must be long at least 8 characters, with at least one lower case character, one upper case and one number.",
     ),
+];
+
+export const confirmEmailVC = [
+  query("code").isUUID().withMessage("email confirmation code is required"),
 ];

--- a/backend/src/middlewares/validations.ts
+++ b/backend/src/middlewares/validations.ts
@@ -1,11 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { validationResult } from "express-validator";
 
-export const checkValidation = (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
+export const validate = (req: Request, res: Response, next: NextFunction) => {
   const validationErrors = validationResult(req);
   if (!validationErrors.isEmpty()) {
     return res.status(400).json({

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -1,7 +1,8 @@
 import { model, Schema } from "mongoose";
-import { User } from "../types/User";
+import IUser from "./user/IUser";
+import { removeUnconfirmedEmail } from "./user/userMethods";
 
-const userSchema = new Schema<User>(
+const userSchema = new Schema<IUser>(
   {
     username: {
       type: String,
@@ -57,4 +58,7 @@ userSchema.index(
   },
 );
 
-export const UserModel = model<User>("user", userSchema);
+// instance methods
+userSchema.methods.removeUnconfirmedEmail = removeUnconfirmedEmail;
+
+export const UserModel = model<IUser>("user", userSchema);

--- a/backend/src/models/user/IUser.d.ts
+++ b/backend/src/models/user/IUser.d.ts
@@ -1,0 +1,8 @@
+import { Document } from "mongoose";
+import { User } from "../../types/User";
+
+interface IUser extends Omit<User, "id">, Document {
+  removeUnconfirmedEmail(): Promise<IUser>;
+}
+
+export default IUser;

--- a/backend/src/models/user/userMethods.ts
+++ b/backend/src/models/user/userMethods.ts
@@ -1,0 +1,8 @@
+import IUser from "./IUser";
+
+export async function removeUnconfirmedEmail(this: IUser): Promise<IUser> {
+  this.unconfirmedEmail = undefined;
+  this.emailConfirmationCode = undefined;
+  this.emailConfirmationCodeExpDate = undefined;
+  return this.save();
+}

--- a/backend/src/routes/v1/auth.ts
+++ b/backend/src/routes/v1/auth.ts
@@ -1,10 +1,12 @@
 import { Router } from "express";
-import { signup } from "./auth/signup";
-import { signupValidationChain } from "../../middlewares/auth";
-import { checkValidation } from "../../middlewares/validations";
+import { confirmEmailVC, signupVC } from "../../middlewares/auth";
+import { validate } from "../../middlewares/validations";
+import signup from "./auth/signup";
+import confirmEmail from "./auth/confirmEmail";
 
 const router = Router();
 
-router.post("/signup", signupValidationChain, checkValidation, signup);
+router.get("/confirm", confirmEmailVC, validate, confirmEmail);
+router.post("/signup", signupVC, validate, signup);
 
 export default router;

--- a/backend/src/routes/v1/auth/__tests__/confirmEmail.test.ts
+++ b/backend/src/routes/v1/auth/__tests__/confirmEmail.test.ts
@@ -1,0 +1,68 @@
+import { UserModel } from "../../../../models/User";
+import request from "supertest";
+import app from "../../../..";
+
+describe.only("GET v1/auth/confirm?code=:confirmationCode", () => {
+  it("200 - should confirm an unconfirmed user", async () => {
+    const emailConfirmationCodeExpDate = new Date();
+    emailConfirmationCodeExpDate.setHours(
+      emailConfirmationCodeExpDate.getHours() + 24
+    );
+
+    // create mock user
+    const user = new UserModel({
+      username: "test user",
+      unconfirmedEmail: "test-confirmEmail@email.com",
+      password: "Password1",
+      emailConfirmationCode: "ea50fae0-9482-42b6-84bb-59f3b641ada9",
+      emailConfirmationCodeExpDate,
+    });
+    await user.save();
+
+    const id: string = user.id;
+
+    // validate user
+    await request(app)
+      .get(`/v1/auth/confirm?code=ea50fae0-9482-42b6-84bb-59f3b641ada9`)
+      .expect(200);
+
+    const confirmedUser = await UserModel.findById(id);
+
+    expect(confirmedUser).not.toBeNull();
+    expect(confirmedUser?.email).toBe("test-confirmEmail@email.com");
+    expect(confirmedUser?.unconfirmedEmail).toBeUndefined();
+    expect(confirmedUser?.emailConfirmationCode).toBeUndefined();
+    expect(confirmedUser?.emailConfirmationCodeExpDate).toBeUndefined();
+  });
+
+  it("400 - should raise an error, missing code", async () => {
+    await request(app).get(`/v1/auth/confirm?code=`).expect(400);
+  });
+
+  it("400 - should raise an error, invalid code", async () => {
+    await request(app).get(`/v1/auth/confirm?code=ciao`).expect(400);
+  });
+
+  it("404 - should raise an error, user not found", async () => {
+    await request(app)
+      .get(`/v1/auth/confirm?code=ea50fae0-9482-42b6-84bb-59f3b641ada9`)
+      .expect(404);
+  });
+
+  it("400 - should raise an error, confirmation code expired", async () => {
+    // create mock user
+    const user = new UserModel({
+      username: "test user",
+      unconfirmedEmail: "test-confirmEmail@email.com",
+      password: "Password1",
+      emailConfirmationCode: "ea50fae0-9482-42b6-84bb-59f3b641ada9",
+      emailConfirmationCodeExpDate: new Date(),
+    });
+    await user.save();
+
+    // validate user
+    await request(app)
+      .get(`/v1/auth/confirm?code=ea50fae0-9482-42b6-84bb-59f3b641ada9`)
+      .expect(400);
+  });
+});

--- a/backend/src/routes/v1/auth/__tests__/signup.test.ts
+++ b/backend/src/routes/v1/auth/__tests__/signup.test.ts
@@ -8,13 +8,13 @@ describe("/signup", () => {
       .post("/v1/auth/signup")
       .send({
         username: "test user",
-        email: "test@email.com",
+        email: "test-signup@email.com",
         password: "Password1",
       })
       .expect(201);
 
     const newUser = await UserModel.findOne({
-      unconfirmedEmail: "test@email.com",
+      unconfirmedEmail: "test-signup@email.com",
     });
     expect(newUser).not.toBeNull();
     expect(newUser?.username).toBe("test user");
@@ -24,7 +24,7 @@ describe("/signup", () => {
     await request(app)
       .post("/v1/auth/signup")
       .send({
-        email: "test@email.com",
+        email: "test-signup@email.com",
         password: "Password1",
       })
       .expect(400);
@@ -45,7 +45,7 @@ describe("/signup", () => {
       .post("/v1/auth/signup")
       .send({
         username: "test user",
-        email: "test@email.com",
+        email: "test-signup@email.com",
       })
       .expect(400);
   });
@@ -66,7 +66,7 @@ describe("/signup", () => {
       .post("/v1/auth/signup")
       .send({
         username: "test user",
-        email: "test@email.com",
+        email: "test-signup@email.com",
         password: "Pass1",
       })
       .expect(400);
@@ -77,7 +77,7 @@ describe("/signup", () => {
       .post("/v1/auth/signup")
       .send({
         username: "test user",
-        email: "test@email.com",
+        email: "test-signup@email.com",
         password: "password1",
       })
       .expect(400);
@@ -88,7 +88,7 @@ describe("/signup", () => {
       .post("/v1/auth/signup")
       .send({
         username: "test user",
-        email: "test@email.com",
+        email: "test-signup@email.com",
         password: "PASSWORD1",
       })
       .expect(400);
@@ -99,7 +99,7 @@ describe("/signup", () => {
       .post("/v1/auth/signup")
       .send({
         username: "test user",
-        email: "test@email.com",
+        email: "test-signup@email.com",
         password: "Password",
       })
       .expect(400);

--- a/backend/src/routes/v1/auth/confirmEmail.ts
+++ b/backend/src/routes/v1/auth/confirmEmail.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from "express";
+import { matchedData } from "express-validator";
+import { UserModel } from "../../../models/User";
+import { connection } from "mongoose";
+
+const confirmEmail = async (req: Request, res: Response) => {
+  try {
+    const { code } = matchedData(req);
+    const user = await UserModel.findOne({
+      emailConfirmationCode: code,
+    });
+
+    // user not found
+    if (!user) {
+      return res.status(404).json({
+        message: "User not found",
+      });
+    }
+
+    // code expired
+    if (
+      !user.emailConfirmationCodeExpDate ||
+      new Date() > user.emailConfirmationCodeExpDate
+    ) {
+      return res.status(400).json({
+        message: "Email confirmation code expired",
+      });
+    }
+
+    await connection.transaction(async () => {
+      // validate email
+      user.email = user.unconfirmedEmail;
+      await user.removeUnconfirmedEmail();
+
+      // remove validated email from other user that are trying to use it as new email
+      const otherUsers = await UserModel.find({
+        unconfirmedEmail: user.email,
+      });
+      await Promise.all(
+        otherUsers.map((user) => user.removeUnconfirmedEmail()),
+      );
+    });
+
+    return res.status(200).json({
+      message: "Confirmed user email",
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      errorKey: "serverError",
+      message: "An error occured while validating user email",
+    });
+  }
+};
+
+export default confirmEmail;

--- a/backend/src/routes/v1/auth/signup.ts
+++ b/backend/src/routes/v1/auth/signup.ts
@@ -5,7 +5,7 @@ import { hashSync } from "bcrypt";
 import { HASH_SALT_ROUNDS } from "../../../utils/constants";
 import { randomUUID } from "crypto";
 
-export const signup = async (req: Request, res: Response) => {
+const signup = async (req: Request, res: Response) => {
   try {
     const { username, email, password } = matchedData(req);
 
@@ -48,3 +48,5 @@ export const signup = async (req: Request, res: Response) => {
     });
   }
 };
+
+export default signup;


### PR DESCRIPTION
This PR introduces an endpoint for confirming a user's email after signup. The endpoint receives a token through query parameters, which is used to verify the user and make their account valid. Additionally, any other accounts using the same email will be updated according to the following logic:

1. A user signs up with an email (unconfirmed status) but hasn't validated their email yet.
2. A second user signs up using the same email (also unconfirmed), attempting to create a separate account with the same email.
3. A third user, who already has a confirmed account, tries to change their email to the same email address used by the first two users.
4. The first user confirms their email using the token they received, becoming a confirmed user.
5. As a result:
    - The second user’s unconfirmed account is removed from the database since they were trying to use an email that is now owned by the first confirmed user.
    - The third user remains confirmed, but the email they attempted to use (which is now owned by the first user) is removed from their account, as it’s no longer available.

This mechanism ensures that only one user can own a particular email and that no unverified users can hold onto an email that has been validated by another user.